### PR TITLE
Minja/dev

### DIFF
--- a/selene_sdk/targets/q_genomic_features.py
+++ b/selene_sdk/targets/q_genomic_features.py
@@ -28,18 +28,16 @@ class qGenomicFeatures(Target):
         """
 
         self.features =  features
+        self._feature_handlers = {}
         self._feature_handlers = {i: pyBigWig.open(j) \
                                             for i,j in zip(features,features_path)
                                       }
-        self.n_features = len(features)
-
-
     def get_feature_data(self, chrom, start, end):
         """
         For a sequence of length :math:`L = end - start`, return the
         features' values corresponding to that region. Feature values
-        are means of quantitative feature values computed over the
-        specified interval.
+        are maximum of quantitative feature values computed observed in
+        the specified interval.
 
         Parameters
         ----------
@@ -54,9 +52,16 @@ class qGenomicFeatures(Target):
         -------
         numpy.ndarray
             array of length N, where N is a number of features, and
-            array[i] is a mean of feature signal over the input genomic
+            array[i] is a max of feature signal over the input genomic
             interval.
 
         """
 
-        return np.array([self._feature_handlers[i].stats(chrom, start, end) for i in self.features])
+        try:
+            results = np.array([self._feature_handlers[i].stats(chrom, start, end, type="max")[0] \
+                                                                                    for i in self.features])
+            return results
+        except:
+            print ("Error loading data on position ",chrom,start,end)
+            import sys
+            sys.exit()

--- a/selene_sdk/utils/config_utils.py
+++ b/selene_sdk/utils/config_utils.py
@@ -180,17 +180,27 @@ def create_data_source(configs, output_dir=None, load_train_val=True, load_test=
                      "validation":[],
                      "test":[]
                      }
-        with open(dataset_info["sampling_intervals_path"]) as f:
-            for line in f:
-                chrom, start, end = line.rstrip().split("\t")[:3]
-                start = int(start)
-                end = int(end)
-                if load_train_val and chrom in dataset_info["validation_holdout"]:
-                    intervals["validation"].append((chrom, start, end))
-                elif load_test and chrom in dataset_info["test_holdout"]:
-                    intervals["test"].append((chrom, start, end))
-                elif load_train_val:
-                    intervals["train"].append((chrom, start, end))
+        for prefix in intervals.keys():
+            if prefix+"_intervals_path" in dataset_info:
+                with open(dataset_info[prefix+"_intervals_path"]) as f:
+                    for line in f:
+                        chrom, start, end = line.rstrip().split("\t")[:3]
+                        start = int(start)
+                        end = int(end)
+                        intervals[prefix].append((chrom, start, end))
+
+        if "sampling_intervals_path" in dataset_info.keys():
+            with open(dataset_info["sampling_intervals_path"]) as f:
+                for line in f:
+                    chrom, start, end = line.rstrip().split("\t")[:3]
+                    start = int(start)
+                    end = int(end)
+                    if load_train_val and chrom in dataset_info["validation_holdout"]:
+                        intervals["validation"].append((chrom, start, end))
+                    elif load_test and chrom in dataset_info["test_holdout"]:
+                        intervals["test"].append((chrom, start, end))
+                    elif load_train_val:
+                        intervals["train"].append((chrom, start, end))
 
         with open(dataset_info["distinct_features_path"]) as f:
             distinct_features = list(map(lambda x: x.rstrip(), f.readlines()))
@@ -245,6 +255,7 @@ def create_data_source(configs, output_dir=None, load_train_val=True, load_test=
                     num_workers=dataset_info["loader_args"]["num_workers"],
                     worker_init_fn=module.encode_worker_init_fn,
                     sampler=sampler,
+                    drop_last=True
                 )
             loaders.append(task_loader)
 


### PR DESCRIPTION
This PR allows more flexible transform of targets. Briefly, it extends metrics `namedtuple` to store transform functions which are applied prior metrics computation. See complementary PR in DeepCT for details.

There are also several small fixes in this PR. For example, it allows specifying separate .bed-files for sampling of train/validation/test intervals. It also changes the aggregation function for quantitative features from _mean_ to _max_. We may like to make this more generic in future, allowing agg function to be specified in config.
